### PR TITLE
modified error in parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -46,7 +46,7 @@ function parse (input) {
   }
 
   if (headerParts.length > 1 && headerParts[1] !== '') {
-    throw new ParserError('No blank line after signature');
+    throw new ParserError('Missing blank line after signature');
   }
 
   const cues = parseCues(parts);


### PR DESCRIPTION
Does 'No blank line after signature' mean there should not be a blank line after the signature or there is a missing blank line after the signature? I think it's better to just use "Missing".