### PR TITLE
Update compiler.js

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,13 +46,13 @@ function compile (input) {
   }
 
   let lastTime = null;
-
-  input.cues.forEach((cue) => {
+  
+  input.cues.forEach((cue,index) => {
     if (lastTime && lastTime > cue.start) {
-      throw new CompilerError('Cues must be in a chronological order');
+      throw new CompilerError(`Cue number ${index} is not in chronological order`);
     }
 
-    lastTime = cue.end;
+    lastTime = cue.start;
 
     output += '\n';
     output += compileCue(cue);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,10 +46,11 @@ function compile (input) {
   }
 
   let lastTime = null;
-  
+
   input.cues.forEach((cue,index) => {
     if (lastTime && lastTime > cue.start) {
-      throw new CompilerError(`Cue number ${index} is not in chronological order`);
+      throw new CompilerError(`Cue number ${index} is not in chronological 
+      order`);
     }
 
     lastTime = cue.start;


### PR DESCRIPTION
Fix checking for time order.
* permit overlap of cues (not comparing end to start, but start to start)
* added an indicator of the offending cue