### PR TITLE
Allow time overlaps, includes tests

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,13 +46,13 @@ function compile (input) {
   }
 
   let lastTime = null;
-
-  input.cues.forEach((cue) => {
+  
+  input.cues.forEach((cue,index) => {
     if (lastTime && lastTime > cue.start) {
-      throw new CompilerError('Cues must be in a chronological order');
+      throw new CompilerError(`Cue number ${index} is not in chronological order`);
     }
 
-    lastTime = cue.end;
+    lastTime = cue.start;
 
     output += '\n';
     output += compileCue(cue);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -47,10 +47,10 @@ function compile (input) {
 
   let lastTime = null;
 
-  input.cues.forEach((cue,index) => {
+  input.cues.forEach((cue, index) => {
     if (lastTime && lastTime > cue.start) {
-      throw new CompilerError(`Cue number ${index} is not in chronological 
-      order`);
+      throw new CompilerError(`Cue number ${index} is not in chronological`
+        + ' order');
     }
 
     lastTime = cue.start;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,10 +46,11 @@ function compile (input) {
   }
 
   let lastTime = null;
-  
+
   input.cues.forEach((cue,index) => {
     if (lastTime && lastTime > cue.start) {
-      throw new CompilerError(`Cue number ${index} is not in chronological order`);
+      throw new CompilerError(`Cue number ${index} is not in chronological 
+      order`);
     }
 
     lastTime = cue.start;

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -470,6 +470,33 @@ Hello world
     };
 
     (() => { compile(input); })
-      .should.throw(compilerError, /Cues must be in a chronological order/);
+      .should.throw(compilerError,
+        /Cue number \d+ is not in chronological order/
+      );
+  });
+
+  it('should allow cues that overlap in time', () => {
+    const input = {
+      valid: true,
+      cues: [
+        {
+          identifier: '',
+          start: 1,
+          end: 5,
+          text: 'This is a subtitle',
+          styles: 'align:start line:0%'
+        },
+        {
+          identifier: '',
+          start: 3,
+          end: 7,
+          text: 'Hello world!',
+          styles: ''
+        }
+      ]
+    };
+
+    (() => { compile(input); })
+      .should.not.throw(compilerError, /Cues must be in a chronological order/);
   });
 });


### PR DESCRIPTION
I paid a fast review of the standard, and I didn't find anything with regard to cues ending after the next cue started, but I found some examples which seemed to suggest that it is valid. (example 8 at https://www.w3.org/TR/webvtt1/)