### PR TITLE
fix rounding error in timestamp

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -156,7 +156,7 @@ function calculateSeconds (time) {
 }
 
 function calculateMs (time) {
-  return Math.floor((time % 1).toFixed(3) * 1000);
+  return Math.floor((time % 1).toFixed(4) * 1000);
 }
 
 module.exports = { CompilerError, compile };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -156,7 +156,7 @@ function calculateSeconds (time) {
 }
 
 function calculateMs (time) {
-  return Math.floor((time % 1) * 1000);
+  return Math.floor((time % 1).toFixed(3) * 1000);
 }
 
 module.exports = { CompilerError, compile };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -184,10 +184,9 @@ function validTimestamp (timestamp) {
 
 function parseTimestamp (timestamp) {
   const matches = timestamp.match(TIMESTAMP_REGEXP);
-
-  let secs = parseFloat(matches[3]);
+  let secs = parseFloat(matches[1] || 0) * 60 * 60; // hours
   secs += parseFloat(matches[2]) * 60; // mins
-  secs += parseFloat(matches[1] || 0) * 60 * 60; // hours
+  secs += parseFloat(matches[3]);
   // secs += parseFloat(matches[4]);
   return secs;
 }

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -271,6 +271,50 @@ Ta en kopp
     compile(input).should.equal(output);
   });
 
+  it('should compile with accurate milliseconds', () => {
+
+    const input = {
+      cues: [{
+        end: 1199.539,
+        identifier: '1',
+        start: 1199.529,
+        styles: '',
+        text: 'Ta en kopp varmt te.\nDet är inte varmt.'
+      }, {
+        end: 1199.549,
+        identifier: '2',
+        start: 1199.539,
+        styles: '',
+        text: 'Har en kopp te.\nDet smakar som te.'
+      }, {
+        end: 1199.558,
+        identifier: '3',
+        start: 1199.549,
+        styles: '',
+        text: 'Ta en kopp'
+      }],
+      valid: true
+    };
+    const output = `WEBVTT
+
+1
+00:19:59.529 --> 00:19:59.539
+Ta en kopp varmt te.
+Det är inte varmt.
+
+2
+00:19:59.539 --> 00:19:59.549
+Har en kopp te.
+Det smakar som te.
+
+3
+00:19:59.549 --> 00:19:59.558
+Ta en kopp
+`;
+
+    compile(input).should.equal(output);
+  });
+
   it('should round properly', () => {
 
     const input = {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -413,4 +413,14 @@ Text Position: 5%
     result.errors.length.should.equal(1);
     result.errors[0].message.should.equal('Invalid cue timestamp (cue #14)');
   });
+
+  it('should parse cue w/o round-off', () => {
+    const input = `WEBVTT
+
+    01:24:39.06 --> 01:24:40.060
+a`;
+
+    parse(input).cues[0].start.should.equal(5079.06);
+    parse(input).cues[0].end.should.equal(5080.06);
+  });
 });


### PR DESCRIPTION
Fixed calculation issues in parser and compiler

### Parser
Output is incorrect for some timestamps if integers are added to floating point.
![image](https://user-images.githubusercontent.com/20624864/82414743-259be600-9a95-11ea-9d86-8b1d16940e33.png)
Sample timestamps for which current function was giving incorrect result
`01:24:40.060`

### Compiler
floatNumber%1 without precision limit changes output
![image](https://user-images.githubusercontent.com/20624864/82415192-cc808200-9a95-11ea-83c5-fa0265b95067.png)
Sample timestamps for which current function gives incorrect result
```
00:19:59.529
00:19:59.539
00:19:59.549
00:19:59.558
01:24:35.275
```