### PR TITLE
Split metadata strings on first colon only

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -74,7 +74,9 @@ function parse (input, options) {
 function parseMeta (headerParts) {
   const meta = {};
   headerParts.slice(1).forEach(header => {
-    const [key, value] = header.split(':').map(t => t.trim());
+    const splitIdx = header.indexOf(':');
+    const key = header.slice(0, splitIdx).trim();
+    const value = header.slice(splitIdx + 1).trim();
     meta[key] = value;
   });
   return Object.keys(meta).length > 0 ? meta : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-webvtt",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-webvtt",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "WebVTT parser, compiler, and segmenter with HLS support",
   "main": "index.js",
   "scripts": {

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -454,7 +454,8 @@ Hello world
     const input = {
       meta: {
         Kind: 'captions',
-        Language: 'en'
+        Language: 'en',
+        'X-TIMESTAMP-MAP=LOCAL': '00:00:00.000,MPEGTS:0'
       },
       cues: [{
         end: 140,
@@ -469,6 +470,7 @@ Hello world
     const output = `WEBVTT
 Kind: captions
 Language: en
+X-TIMESTAMP-MAP=LOCAL: 00:00:00.000,MPEGTS:0
 
 1
 00:02:15.001 --> 00:02:20.000

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -299,6 +299,7 @@ Language: en
     const input = `WEBVTT
 Kind: captions
 Language: en
+X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0
 
 1
 00:00.000 --> 00:00.001`;
@@ -306,7 +307,11 @@ Language: en
 
     parse(input, options).should.have.property('valid').be.true;
     parse(input, options).should.have.property('meta').be.deep.equal(
-      { Kind: 'captions', Language: 'en' }
+      {
+        Kind: 'captions',
+        Language: 'en',
+        'X-TIMESTAMP-MAP=LOCAL': '00:00:00.000,MPEGTS:0'
+      }
     );
   });
 


### PR DESCRIPTION
fixes #37

Code change to handle metadata fields that contain multiple colons.
For example: `X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0`

See WebVtt specs:
https://tools.ietf.org/html/rfc8216#section-3.5

Thanks for this awesome module.

This PR only prevents the code from breaking when multiple colons are present in the metadata string. 
It does not include actual full support for `X-TIMESTAMP-MAP`

Also seeing some work around this metadata in this code:
https://github.com/osk/node-webvtt/blob/master/lib/hls.js#L17

But that line does not match the specs for `X-TIMESTAMP-MAP`.
Please let me know if you rather I focus on that part of the code, instead of my current PR.