### PR TITLE
Support longer times

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,7 +11,7 @@ function ParserError (message, error) {
 
 ParserError.prototype = Object.create(Error.prototype);
 
-const TIMESTAMP_REGEXP = /([0-9]{1,2})?:?([0-9]{2}):([0-9]{2}\.[0-9]{2,3})/;
+const TIMESTAMP_REGEXP = /([0-9]+)?:?([0-9]{2}):([0-9]{2}\.[0-9]{2,3})/;
 
 function parse (input, options) {
   if (!options) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -105,6 +105,16 @@ a`;
     parse(input).cues[0].end.should.equal(0.001);
   });
 
+  it('should parse cue with long hours timestamp', () => {
+    const input = `WEBVTT
+
+10000:00:00.000 --> 10000:00:00.001
+a`;
+
+    parse(input).cues[0].start.should.equal(36000000);
+    parse(input).cues[0].end.should.equal(36000000.001);
+  });
+
   it('should return parsed data about a single cue', () => {
     const input = `WEBVTT
 


### PR DESCRIPTION
This PR fixes the timestamp regular expression to recognize timestamps with more than 2 digits of "hours."


Resolves #117