### PR TITLE
strictly follow segment duration

### DIFF
--- a/lib/segmenter.js
+++ b/lib/segmenter.js
@@ -2,7 +2,7 @@
 
 const parse = require('./parser').parse;
 
-function segment(input, segmentLength) {
+function segment (input, segmentLength) {
   segmentLength = segmentLength || 10;
 
   const parsed = parse(input);
@@ -56,10 +56,11 @@ function segment(input, segmentLength) {
         currentSegmentDuration,
         totalSegmentsDuration);
 
-      segments.push({duration, cues});
+      segments.push({ duration, cues });
 
       totalSegmentsDuration += duration;
-      currentSegmentDuration = cueLength + silence; // Reset to current cue duration
+      // Reset to current cue duration
+      currentSegmentDuration = cueLength + silence;
       cues = [cue]; // Start new segment with current cue
     } else {
       shouldQueue = false;
@@ -73,13 +74,7 @@ function segment(input, segmentLength) {
   return segments;
 }
 
-function shouldSegment(total, length, nextStart, silence) {
-  const x = alignToSegmentLength(silence, length);
-  const nextCueIsInNextSegment = silence <= length || x + total < nextStart;
-  return nextCueIsInNextSegment && nextStart - total >= length;
-}
-
-function segmentDuration(lastCue, end, length, currentSegment, totalSegments) {
+function segmentDuration (lastCue, end, length, currentSegment, totalSegments) {
   let duration = length;
 
   if (currentSegment > length) {
@@ -95,7 +90,7 @@ function segmentDuration(lastCue, end, length, currentSegment, totalSegments) {
   return duration;
 }
 
-function alignToSegmentLength(n, segmentLength) {
+function alignToSegmentLength (n, segmentLength) {
   n += segmentLength - n % segmentLength;
   return n;
 }
@@ -103,10 +98,10 @@ function alignToSegmentLength(n, segmentLength) {
 const debugging = false;
 
 /* istanbul ignore next */
-function debug(m) {
+function debug (m) {
   if (debugging) {
     console.log(m);
   }
 }
 
-module.exports = {segment};
+module.exports = { segment };

--- a/lib/segmenter.js
+++ b/lib/segmenter.js
@@ -2,7 +2,7 @@
 
 const parse = require('./parser').parse;
 
-function segment (input, segmentLength) {
+function segment(input, segmentLength) {
   segmentLength = segmentLength || 10;
 
   const parsed = parse(input);
@@ -32,6 +32,7 @@ function segment (input, segmentLength) {
     debug(`Start ${start}`);
     debug(`End ${end}`);
     debug(`Length ${cueLength}`);
+    debug(`Silence ${silence}`);
     debug(`Total segment duration = ${totalSegmentsDuration}`);
     debug(`Current segment duration = ${currentSegmentDuration}`);
     debug(`Start of next = ${nextStart}`);
@@ -47,21 +48,19 @@ function segment (input, segmentLength) {
 
     // if a cue passes a segment boundary, it appears in both
     let shouldQueue = nextStart - end < segmentLength &&
-                        silence < segmentLength &&
-                        currentSegmentDuration > segmentLength;
+      silence < segmentLength &&
+      currentSegmentDuration > segmentLength;
 
-    if (shouldSegment(totalSegmentsDuration, segmentLength, nextStart,
-      silence)) {
-
+    if (currentSegmentDuration >= segmentLength) {
       const duration = segmentDuration(lastCue, end, segmentLength,
         currentSegmentDuration,
         totalSegmentsDuration);
 
-      segments.push({ duration, cues });
+      segments.push({duration, cues});
 
       totalSegmentsDuration += duration;
-      currentSegmentDuration = 0;
-      cues = [];
+      currentSegmentDuration = cueLength + silence; // Reset to current cue duration
+      cues = [cue]; // Start new segment with current cue
     } else {
       shouldQueue = false;
     }
@@ -74,24 +73,19 @@ function segment (input, segmentLength) {
   return segments;
 }
 
-function shouldSegment (total, length, nextStart, silence) {
-
-  // this is stupid, but gets one case fixed...
+function shouldSegment(total, length, nextStart, silence) {
   const x = alignToSegmentLength(silence, length);
-  const nextCueIsInNextSegment = silence <= length ||
-                                 x + total < nextStart;
-
+  const nextCueIsInNextSegment = silence <= length || x + total < nextStart;
   return nextCueIsInNextSegment && nextStart - total >= length;
 }
 
-function segmentDuration (lastCue, end, length, currentSegment, totalSegments) {
+function segmentDuration(lastCue, end, length, currentSegment, totalSegments) {
   let duration = length;
 
   if (currentSegment > length) {
     duration = alignToSegmentLength(currentSegment - length, length);
   }
 
-  // make sure the last cue covers the whole time of the cues
   if (lastCue) {
     duration = parseFloat((end - totalSegments).toFixed(2));
   } else {
@@ -101,7 +95,7 @@ function segmentDuration (lastCue, end, length, currentSegment, totalSegments) {
   return duration;
 }
 
-function alignToSegmentLength (n, segmentLength) {
+function alignToSegmentLength(n, segmentLength) {
   n += segmentLength - n % segmentLength;
   return n;
 }
@@ -109,10 +103,10 @@ function alignToSegmentLength (n, segmentLength) {
 const debugging = false;
 
 /* istanbul ignore next */
-function debug (m) {
+function debug(m) {
   if (debugging) {
     console.log(m);
   }
 }
 
-module.exports = { segment };
+module.exports = {segment};


### PR DESCRIPTION
Current implementation of segmented playlist allows last segment duration longer than the specified length. 
when using these hls assets in vod2live, it causes misalignment and stale playback due to difference in segment duration between video/audio and subtitles.

This pull request prevent segments from being longer than the specified length.