### PR TITLE
Add style validation for timestamps

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -167,8 +167,15 @@ function parseCue (cue, i, strict) {
     );
   }
 
-  // TODO better style validation
   styles = times[1].replace(TIMESTAMP_REGEXP, '').trim();
+
+  if (styles !== '') {
+    styles.split(' ').forEach((style) => {
+      if (!style.includes(':')) {
+        throw new ParserError(`Invalid inline style (cue #${i})`);
+      }
+    });
+  }
 
   lines.shift();
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -478,4 +478,14 @@ a`;
         .should.throw(parserError, /Invalid cue timestamp/);
     }
   );
+
+  it('should throw an error if the inline style is invalid', () => {
+    const input = `WEBVTT
+
+1
+00:00.000 --> 00:00.001 0`;
+
+    (() => { parse(input); })
+      .should.throw(parserError, /Invalid inline style/);
+  });
 });


### PR DESCRIPTION
Proposal to introduce a style validation for timestamps

Styles should be provided in the following format

```
00:00.000 --> 00:01.001 align:start line:0%
```

Validate the styles are specified correctly